### PR TITLE
Change register_api_field() -> register_rest_field()

### DIFF
--- a/includes/admin_custom_api.php
+++ b/includes/admin_custom_api.php
@@ -103,7 +103,7 @@ class admin_js_app_api {
 
     function register_custom_fields() {
 
-        register_api_field( 'book',
+        register_rest_field( 'book',
             'meta',
             array(
                 'get_callback'    => array( $this, 'get_book_meta' ),


### PR DESCRIPTION
v2 is renaming and deprecating register_api_field(), see
https://github.com/WP-API/WP-API/issues/1321